### PR TITLE
Some Bugfixes + Additions: typos, prefixes, terminology

### DIFF
--- a/shoebox/src/Shoebox.hs
+++ b/shoebox/src/Shoebox.hs
@@ -6,16 +6,19 @@ import qualified Data.Map as M
 import Data.Maybe
 
 -- types of databases
-type ShoeParsingDB = M.Map Text [MorphemeBreak]  -- parsing
+type ShoeSegmentationDB = M.Map Text [MorphemeBreak]  -- segmentation
 type ShoeLexiconDB = M.Map LexEl [Meaning]       -- base words, lexicon
 type ShoeSuffixDB  = M.Map SuffixEl [Abbreviation] -- suffixes
+type ShoePrefixDB  = M.Map PrefixEl [Abbreviation] -- prefixes
 
 type SuffixEl = Text
+type PrefixEl = Text
 type Abbreviation = Text
 type Meaning = Text
 type LexEl  = Text  -- inside lexicon
 type FullEl = Text -- full element
 type Suffix = Text -- suffix
+type Prefix = Text -- prefix
 
 data GlossChoice = AbbreviationChoice [Abbreviation]
                  | MeaningChoice [Meaning]
@@ -28,7 +31,7 @@ data Gloss = Abbreviation Abbreviation
 newtype MorphemeBreak = MB [Morpheme]
   deriving (Show,Eq)
 
-data Morpheme = MorphemeLex LexEl | MorphemeSuffix Suffix
+data Morpheme = MorphemeLex LexEl | MorphemeSuffix Suffix | MorphemePrefix Prefix
   deriving (Show,Eq)
 
 data InterlinearBlock = ILB MorphemeBreak [GlossChoice]
@@ -39,15 +42,25 @@ type TextEl = Text
 shoeLexiconDB :: ShoeLexiconDB
 shoeLexiconDB = M.fromList
   [ ("maison",["house", "building"])
+   	, ("lorsque",["when"]
+   	, ("avoir",["to_have"]
+   	, ("six",["six"]
+   	, ("an",["year"]
   ]
 
 shoeSuffixDB :: ShoeSuffixDB
 shoeSuffixDB = M.fromList
   [ ("s",["PL"])
+  	, ("ais",["1sIPF"])
   ]
 
-shoeParsingDB :: ShoeParsingDB
-shoeParsingDB = M.fromList
+shoePrefixDB :: ShoePrefixDB
+shoePrefixDB = M.fromList
+  [ ("je",["1sPRON"])
+  ]
+
+shoeSegmentationDB :: ShoeSegmentationDB
+shoeSegmentationDB = M.fromList
    [ ("maisons", [ MB [ MorphemeLex "maison"
                       , MorphemeSuffix "s"
                       ]
@@ -58,26 +71,33 @@ shoeParsingDB = M.fromList
                       ]
                  ]
      )
+   , ("j'avais", [ MB [ MorphemePrefix "je"
+	 										, MorphemeLex "avoir"
+                      , MorphemeSuffix "ais"
+                      ]
+                 ]
+     )
    ]
 
-type ShoeDB = (ShoeLexiconDB, ShoeSuffixDB, ShoeParsingDB)
+type ShoeDB = (ShoeLexiconDB, ShoeSuffixDB, ShoePrefixDB, ShoeSegmentationDB)
 
 shoeDB :: ShoeDB
-shoeDB = (shoeLexiconDB, shoeSuffixDB, shoeParsingDB)
+shoeDB = (shoeLexiconDB, shoeSuffixDB, shoePrefixDB, shoeSegmentationDB)
 
-glossTX :: TextEl -> ShoeParsingDB -> [MorphemeBreak]
-glossTX textEl parsingDB =
+breakTX :: TextEl -> ShoeSegmentationDB -> [MorphemeBreak]
+breakTX textEl segmentationDB =
   fromMaybe [MB [MorphemeLex textEl]]
-    (M.lookup textEl parsingDB)
+    (M.lookup textEl segmentationDB)
 
-glossMB :: MorphemeBreak -> ShoeLexiconDB -> ShoeSuffixDB -> [GlossChoice]
-glossMB (MB mbs) lexiconDB suffixDB = map go mbs
+lookupMB :: MorphemeBreak -> ShoeLexiconDB -> ShoeSuffixDB -> ShoePrefixDB -> [GlossChoice]
+lookupMB (MB mbs) lexiconDB suffixDB prefixDB = map go mbs
   where
     go (MorphemeLex l)    = MeaningChoice $      fromMaybe [] (M.lookup l lexiconDB)
     go (MorphemeSuffix s) = AbbreviationChoice $ fromMaybe [] (M.lookup s suffixDB)
+    go (MorphemePrefix p) = AbbreviationChoice $ fromMaybe [] (M.lookup s prefixDB)
 
 gloss :: TextEl -> ShoeDB -> [InterlinearBlock]
-gloss textEl (lexiconDB,suffixDB,parsingDB) = do
-  morphemeBreak <- glossTX textEl parsingDB
-  let glosses = glossMB morphemeBreak lexiconDB suffixDB
+gloss textEl (lexiconDB,suffixDB,segmentationDB) = do
+  morphemeBreak <- breakTX textEl segmentationDB
+  let glosses = lookupMB morphemeBreak lexiconDB suffixDB prefixDB
   return $ ILB morphemeBreak glosses

--- a/shoebox/test/ShoeboxSpec.hs
+++ b/shoebox/test/ShoeboxSpec.hs
@@ -11,11 +11,11 @@ spec :: Spec
 spec = describe "Shoebox" $ do
 
   it "can break up a piece of text into morphemes" $ do
-    glossTX "maisons" shoeParsingDB `shouldBe` [ MB [MorphemeLex "maison", MorphemeSuffix "s"] ]
-    glossTX "cadeaux" shoeParsingDB `shouldBe` [ MB [MorphemeLex "cadeau", MorphemeSuffix "s"] ]
+    glossTX "maisons" shoeSegmentationDB `shouldBe` [ MB [MorphemeLex "maison", MorphemeSuffix "s"] ]
+    glossTX "cadeaux" shoeSegmentationDB `shouldBe` [ MB [MorphemeLex "cadeau", MorphemeSuffix "s"] ]
 
-  it "can lookup the meanings of a morpheme break" $
-    glossMB (MB [MorphemeLex "maison", MorphemeSuffix "s"])
+  it "can lookup the meanings of a morpheme break" $ do
+    lookupMB (MB [MorphemeLex "maison", MorphemeSuffix "s"])
             shoeLexiconDB shoeSuffixDB
       `shouldBe` [ MeaningChoice ["house", "building"], AbbreviationChoice ["PL"] ]
 	
@@ -43,7 +43,7 @@ spec = describe "Shoebox" $ do
 			`shouldBe`
 			"This however is an example for removed punctuation-marks ignoring in-word punctuation like in dates or abbreviations e.g. 21.10.2015"
 
-	it "can convert a single data set from a lexical database"
+	it "can convert a single data set from a lexical database" $ do
 		importLexDBElem "\\le abaisser\n\\_no 00001\n\\me senken; herabsetzen; herunterlassen; vermindern; entwürdigen; demütigen\n\\lk 4\n\\co \n\\dt 17/Aug/15"
 			`shouldBe`
     ("abaisser", [ ME [ "senken", "herabsetzen", "herunterlassen", "vermindern", "entwürdigen", "demütigen" ],
@@ -54,8 +54,8 @@ spec = describe "Shoebox" $ do
                  ]
      )
 
-	it "can convert a single data set from a suffix database"
-	 importSuffDBFile "\\le a\n\\_no 00002\n\\me 3sPF; 3sFUT\n\\co" 
+	it "can convert a single data set from a suffix database" $ do
+	 importSuffDBElem "\\le a\n\\_no 00002\n\\me 3sPF; 3sFUT\n\\co" 
 	 	`shouldBe`
     ("a", [ ME [ "3sPF", "3sFUT" ],
 					  UUID [genuuid],
@@ -63,8 +63,8 @@ spec = describe "Shoebox" $ do
                  ]
      )
 
-	it "can extract prefixes from a parsing database"
-		importParsingDB shoeSuffixDB "\\fl j'avais\n\\_no 03218\n\\bk je-avoir-ais" 
+	it "can extract prefixes from a segmentation (former "parsing") database" $ do
+		importPrefixDB shoeSuffixDB "\\fl j'avais\n\\_no 03218\n\\bk je-avoir-ais" 
 			`shouldBe`
     ("je", [ ME [ "1sPRON" ],
 					  UUID [genuuid],
@@ -72,8 +72,8 @@ spec = describe "Shoebox" $ do
                  ]
      )
 	
-	it "can convert a single data set from a parsing database"
-		importParsingDB shoeSuffixDB shoePrefixDB "\\fl j'avais\n\\_no 03218\n\\bk je-avoir-ais" 
+	it "can convert a single data set from a segmentation database" $ do
+		importiSegmentationDBElem shoeSuffixDB shoePrefixDB "\\fl j'avais\n\\_no 03218\n\\bk je-avoir-ais" 
 			`shouldBe`
    		 ("j'avais", [ MB [ MorphemePrefix "je"
 			 								,	MorphemeLex "avoir"
@@ -82,7 +82,7 @@ spec = describe "Shoebox" $ do
                       ]
                  ]
      		)
-		importParsingDB shoeSuffixDB shoePrefixDB	"\\fl l'a\n\\_no 03306\n\\bk le-avoir-e; la-avoir-e"
+		importSegmentationDBElem shoeSuffixDB shoePrefixDB	"\\fl l'a\n\\_no 03306\n\\bk le-avoir-e; la-avoir-e"
 			`shouldBe`
    		 ("j'avais", [ MB [ MorphemePrefix "le"
 			 								,	MorphemeLex "avoir"

--- a/shoebox/todo.txt
+++ b/shoebox/todo.txt
@@ -30,7 +30,7 @@ intl :: [TextEl] -> ShoeDB -> [InterlinearBlock]
 or rather: which takes a sentence (being a string of textelements seperated by whitespace):
 intl :: Text -> ShoeDB -> [InterlinearBlock]
 
-Interlinearization should proceed either until the last textelement has been reached or until one pf
+Interlinearization should proceed either until the last textelement has been reached or until one of
 them returned an ABORT-Signal. (In this case the remaining following textelements should be glossed with empty
 lists.)
 
@@ -138,5 +138,12 @@ Also needs a preprocessing, which scans for possible detached affixes.
 7. DSL for configuration of advanced scenarios
 (to be discussed)
 
+8. strip off punctuation:
+
+import qualified Data.Set as S
+punctuation = S.fromList ",?,-;'\""
+removePunc = filter (`S.notMember` punctuation)
+
+(should be refined so that punctuation is only being removed in front or after whitespace!)
 
 


### PR DESCRIPTION
- Corrected some typos
- Added PrefixDB and functionality for prefixes
- Added some meat to the hardcoded data to make the tests work
- Changed "Parsing" into "Segmention" which is more adequate terminology
- changed glossTX and glossMB into breakTX and lookupMB
